### PR TITLE
Add inline preedit rendering for Korean/CJK IME on macOS

### DIFF
--- a/VVTerm/GhosttyTerminal/GhosttyIMEHandler.swift
+++ b/VVTerm/GhosttyTerminal/GhosttyIMEHandler.swift
@@ -21,6 +21,12 @@ class GhosttyIMEHandler {
     /// Track marked text for IME composition
     private(set) var markedText: String = ""
 
+    /// Track selected range within marked text (set by IME via setMarkedText)
+    private var markedSelectedRange: NSRange = NSRange(location: 0, length: 0)
+
+    /// Last preedit text sent to Ghostty to avoid redundant updates
+    private var renderedPreeditText: String?
+
     /// Attributes for displaying marked text
     private let markedTextAttributes: [NSAttributedString.Key: Any] = [
         .underlineStyle: NSUnderlineStyle.single.rawValue,
@@ -67,8 +73,10 @@ class GhosttyIMEHandler {
     func clearMarkedText() {
         if !markedText.isEmpty {
             markedText = ""
+            markedSelectedRange = NSRange(location: 0, length: 0)
             view?.needsDisplay = true
         }
+        syncPreedit(nil)
     }
 
     // MARK: - NSTextInputClient Methods
@@ -93,12 +101,16 @@ class GhosttyIMEHandler {
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
         guard let text = anyToString(string) else { return }
 
-        // Update marked text state
+        // Update marked text and selection state
         markedText = text
+        markedSelectedRange = selectedRange
 
         // Tell system we've handled the marked text
         view?.inputContext?.invalidateCharacterCoordinates()
         view?.needsDisplay = true
+
+        // Render preedit inline in terminal (Korean Hangul, CJK, etc.)
+        syncPreedit(markedText)
 
         Self.logger.debug("IME marked text: \(text)")
     }
@@ -110,8 +122,15 @@ class GhosttyIMEHandler {
     }
 
     func selectedRange() -> NSRange {
-        // Terminals don't have text selection in the traditional sense for IME
-        return NSRange(location: NSNotFound, length: 0)
+        // Return cursor position relative to marked text for proper IME interaction.
+        // NSNotFound can cause some Korean/CJK IMEs to malfunction.
+        if !markedText.isEmpty {
+            return NSRange(
+                location: markedSelectedRange.location,
+                length: markedSelectedRange.length
+            )
+        }
+        return NSRange(location: 0, length: 0)
     }
 
     func markedRange() -> NSRange {
@@ -181,6 +200,61 @@ class GhosttyIMEHandler {
 
     func characterIndex(for point: NSPoint) -> Int {
         return NSNotFound
+    }
+
+    // MARK: - Inline Preedit Rendering
+
+    /// Send preedit text to Ghostty for inline rendering in the terminal.
+    /// Uses TerminalVisiblePreeditPolicy to determine whether the text should be displayed
+    /// (always true for Hangul/CJK scripts, conditionally for romanized Chinese/Japanese).
+    private func syncPreedit(_ text: String?) {
+        let visibleText: String?
+        if let text, !text.isEmpty {
+            let normalized = text.precomposedStringWithCanonicalMapping
+            visibleText = TerminalVisiblePreeditPolicy.shouldDisplay(
+                normalized,
+                inputModePrimaryLanguage: currentInputLanguage
+            ) ? normalized : nil
+        } else {
+            visibleText = nil
+        }
+
+        guard visibleText != renderedPreeditText else { return }
+        renderedPreeditText = visibleText
+
+        guard let cSurface = surface?.unsafeCValue else { return }
+
+        if let visibleText, !visibleText.isEmpty {
+            let len = visibleText.utf8CString.count
+            guard len > 0 else {
+                ghostty_surface_preedit(cSurface, nil, 0)
+                view?.needsDisplay = true
+                return
+            }
+            visibleText.withCString { ptr in
+                ghostty_surface_preedit(cSurface, ptr, UInt(len - 1))
+            }
+        } else {
+            ghostty_surface_preedit(cSurface, nil, 0)
+        }
+
+        view?.needsDisplay = true
+    }
+
+    /// Get current input source language for preedit policy decisions.
+    /// Korean Hangul preedit is always displayed regardless of this value
+    /// (detected by Unicode range), but Chinese/Japanese romanized preedit
+    /// requires language identification.
+    private var currentInputLanguage: String? {
+        guard let sourceID = view?.inputContext?.selectedKeyboardInputSource?.lowercased() else {
+            return nil
+        }
+        if sourceID.contains("korean") || sourceID.contains("hangul") { return "ko" }
+        if sourceID.contains("chinese") || sourceID.contains("scim") || sourceID.contains("tcim")
+            || sourceID.contains("pinyin") || sourceID.contains("wubi")
+            || sourceID.contains("cangjie") || sourceID.contains("zhuyin") { return "zh" }
+        if sourceID.contains("japanese") || sourceID.contains("kotoeri") { return "ja" }
+        return nil
     }
 
     // MARK: - Helper


### PR DESCRIPTION
## Summary

- **macOS Korean IME composition text is invisible in the terminal.** When typing Korean (Hangul) in the terminal on macOS, the composition text (e.g. ㅎ→하→한) is not rendered inline — users can only see it in the floating IME candidate window. This makes Korean input very difficult in practice, as you're typing blind inside the terminal.
- iOS already calls `ghostty_surface_preedit` to render composition text inline, but the macOS `GhosttyIMEHandler` was missing this entirely.
- This also affects other CJK input methods (Chinese, Japanese) that rely on inline preedit display.

## Changes

- **Inline preedit rendering**: Call `ghostty_surface_preedit` from `setMarkedText`/`clearMarkedText` to show composition text at the cursor, matching the existing iOS implementation
- **Track `markedSelectedRange`**: Store the `selectedRange` parameter from `setMarkedText` instead of discarding it
- **Fix `selectedRange()` return value**: Return the actual IME cursor position instead of `NSNotFound`, which can cause some Korean/CJK IMEs to malfunction (e.g. first character lost, mispositioned candidates)
- **Input source language detection**: Identify current input language from `NSTextInputContext` for `TerminalVisiblePreeditPolicy` (Korean Hangul preedit is always shown by Unicode range detection; this additionally enables romanized preedit for Chinese pinyin/Japanese romaji)
- **Redundant update guard**: Cache `renderedPreeditText` to skip unnecessary `ghostty_surface_preedit` calls

## Why this matters

Korean is a composing script — each syllable is built incrementally from individual jamo (ㅎ+ㅏ+ㄴ = 한). Without inline preedit, users cannot see the intermediate composition state in the terminal, making Korean input essentially unusable for anything beyond short commands. This is a fundamental usability issue for Korean-speaking users.

## Test plan

- [ ] Switch macOS input to Korean (2-Set) and type in terminal — composition (ㅎ→하→한) should appear inline at cursor
- [ ] Press Space/Enter to commit — preedit clears, committed text appears
- [ ] Press ESC during composition — preedit clears without committing
- [ ] Switch to English input mid-composition — composition commits, English input works normally
- [ ] Verify Japanese (Kana) and Chinese (Pinyin) preedit also renders inline
- [ ] Verify no regression with English-only input

🤖 Generated with [Claude Code](https://claude.com/claude-code)