### PR TITLE
Add terminal content padding for cleaner appearance

### DIFF
--- a/VVTerm/GhosttyTerminal/Ghostty.App.swift
+++ b/VVTerm/GhosttyTerminal/Ghostty.App.swift
@@ -345,9 +345,9 @@ extension Ghostty {
                 font-family = \(terminalFontName)
                 font-size = \(Int(terminalFontSize))
                 window-inherit-font-size = false
-                window-padding-balance = false
-                window-padding-x = 0
-                window-padding-y = 0
+                window-padding-balance = true
+                window-padding-x = 4
+                window-padding-y = 2,0
                 window-padding-color = extend-always
 
                 # Enable shell integration (resources dir auto-detected from app bundle)


### PR DESCRIPTION
## Summary

- Add small padding around terminal content so text doesn't touch the view edges
- Background color extends uniformly into the padding area via `window-padding-color = extend-always`
- Uses `window-padding-balance = true` to center content within the available space

## Changes

In `Ghostty.App.swift`, the Ghostty config now sets:
- `window-padding-x = 4` (4px horizontal padding)
- `window-padding-y = 2,0` (2px top padding, 0 bottom)
- `window-padding-balance = true` (balanced padding distribution)

This is a purely visual change — no functional impact on terminal behavior, input handling, or rendering.

## Why

Terminal content currently renders edge-to-edge with no breathing room. A small padding creates a cleaner, more polished look — consistent with modern terminal emulators like iTerm2, Warp, and Ghostty's own defaults.

## Test plan

- [ ] Verify padding is visible around terminal content on macOS
- [ ] Verify padding area uses the terminal background color (no color seams)
- [ ] Verify terminal resize still works correctly with padding
- [ ] Verify iOS terminal rendering is not affected
- [ ] Verify no regression in text selection near edges