### PR TITLE
fix: keep macOS terminal paste routed to the active tab

### DIFF
--- a/VVTerm/Features/TerminalSessions/Application/TerminalTabManager.swift
+++ b/VVTerm/Features/TerminalSessions/Application/TerminalTabManager.swift
@@ -131,7 +131,7 @@ final class TerminalTabManager: ObservableObject {
     }
 
     func shouldGrantTerminalFocus(to paneId: UUID, for serverId: UUID) -> Bool {
-        guard selectedViewByServer[serverId] == "terminal",
+        guard ViewTabConfigurationManager.shared.effectiveView(for: selectedViewByServer[serverId]) == "terminal",
               let selectedTab = selectedTab(for: serverId) else { return false }
         return selectedTab.focusedPaneId == paneId
     }

--- a/VVTerm/Features/TerminalSessions/Application/TerminalTabManager.swift
+++ b/VVTerm/Features/TerminalSessions/Application/TerminalTabManager.swift
@@ -130,6 +130,12 @@ final class TerminalTabManager: ObservableObject {
         return tabs(for: serverId).first { $0.id == tabId }
     }
 
+    func shouldGrantTerminalFocus(to paneId: UUID, for serverId: UUID) -> Bool {
+        guard selectedViewByServer[serverId] == "terminal",
+              let selectedTab = selectedTab(for: serverId) else { return false }
+        return selectedTab.focusedPaneId == paneId
+    }
+
     /// Check if can open new tab (Pro limit check)
     var canOpenNewTab: Bool {
         if StoreManager.shared.isPro { return true }

--- a/VVTerm/Features/TerminalSessions/UI/Splits/TerminalView.swift
+++ b/VVTerm/Features/TerminalSessions/UI/Splits/TerminalView.swift
@@ -1033,32 +1033,26 @@ struct SSHTerminalPaneWrapper: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        // Ensure terminal has focus when active
         if let scrollView = nsView as? TerminalScrollView {
             let terminalView = scrollView.surfaceView
-
-            // Track active state change
             let wasActive = context.coordinator.wasActive
             context.coordinator.wasActive = isActive
+            context.coordinator.focusRequestID &+= 1
 
-            if isActive {
-                // Always try to set focus when active
-                if let window = nsView.window, window.firstResponder != terminalView {
-                    // Use async to ensure view hierarchy is ready
-                    DispatchQueue.main.async {
-                        if let window = terminalView.window {
-                            window.makeFirstResponder(terminalView)
-                        }
-                    }
-                }
-            }
+            let currentWindowIdentity = nsView.window.map(ObjectIdentifier.init)
+            let didAttachToWindow = currentWindowIdentity != nil && currentWindowIdentity != context.coordinator.lastWindowIdentity
+            context.coordinator.lastWindowIdentity = currentWindowIdentity
 
-            // If just became active, force focus
-            if isActive && !wasActive {
+            if isActive && (!wasActive || didAttachToWindow) {
+                let focusRequestID = context.coordinator.focusRequestID
+                let paneId = paneId
+                let serverId = server.id
                 DispatchQueue.main.async {
-                    if let window = terminalView.window {
+                    guard context.coordinator.focusRequestID == focusRequestID,
+                          TerminalTabManager.shared.shouldGrantTerminalFocus(to: paneId, for: serverId),
+                          let window = terminalView.window,
+                          window.firstResponder !== terminalView else { return }
                         window.makeFirstResponder(terminalView)
-                    }
                 }
             }
         }
@@ -1089,6 +1083,8 @@ struct SSHTerminalPaneWrapper: NSViewRepresentable {
         var shellTask: Task<Void, Never>?
         var isReusingTerminal = false
         var wasActive = false
+        var lastWindowIdentity: ObjectIdentifier?
+        var focusRequestID: UInt = 0
         private let richPasteRuntime: TerminalRichPasteRuntime
         private var lastSize: (cols: Int, rows: Int) = (0, 0)
         private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "VVTerm", category: "SSHPane")

--- a/VVTerm/Features/TerminalSessions/UI/Splits/TerminalView.swift
+++ b/VVTerm/Features/TerminalSessions/UI/Splits/TerminalView.swift
@@ -1052,7 +1052,7 @@ struct SSHTerminalPaneWrapper: NSViewRepresentable {
                           TerminalTabManager.shared.shouldGrantTerminalFocus(to: paneId, for: serverId),
                           let window = terminalView.window,
                           window.firstResponder !== terminalView else { return }
-                        window.makeFirstResponder(terminalView)
+                    window.makeFirstResponder(terminalView)
                 }
             }
         }

--- a/VVTerm/Features/TerminalSessions/UI/Tabs/ConnectionTabsView.swift
+++ b/VVTerm/Features/TerminalSessions/UI/Tabs/ConnectionTabsView.swift
@@ -40,6 +40,7 @@ struct ConnectionTerminalContainer: View {
     @State private var showingZenPanel = false
     #if os(macOS)
     @State private var zenWindowSafeAreaInsets = EdgeInsets()
+    @State private var hostingWindow: NSWindow?
     #endif
 
     /// Selected view type - persisted per server
@@ -144,6 +145,8 @@ struct ConnectionTerminalContainer: View {
                     MacOSZenWindowChromeBridge(contentInsets: $zenWindowSafeAreaInsets)
                         .frame(width: 0, height: 0)
                 }
+                HostingWindowObserver(window: $hostingWindow)
+                    .frame(width: 0, height: 0)
                 #endif
             }
             .macOSZenExpandedTopSafeArea(isZenModeEnabled && selectedView == "terminal")
@@ -318,7 +321,7 @@ struct ConnectionTerminalContainer: View {
         let serverId = server.id
         DispatchQueue.main.async {
             guard TerminalTabManager.shared.selectedViewByServer[serverId] != "terminal" else { return }
-            guard let window = NSApp.keyWindow,
+            guard let window = hostingWindow,
                   window.firstResponder is GhosttyTerminalView else { return }
             window.makeFirstResponder(nil)
         }
@@ -635,6 +638,45 @@ struct ConnectionTerminalContainer: View {
     }
     #endif
 }
+
+#if os(macOS)
+private struct HostingWindowObserver: NSViewRepresentable {
+    @Binding var window: NSWindow?
+
+    func makeNSView(context: Context) -> WindowObserverView {
+        let view = WindowObserverView()
+        view.onWindowChange = { [binding = _window] newWindow in
+            binding.wrappedValue = newWindow
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: WindowObserverView, context: Context) {
+        nsView.onWindowChange = { [binding = _window] newWindow in
+            binding.wrappedValue = newWindow
+        }
+        nsView.publishCurrentWindow()
+    }
+}
+
+private final class WindowObserverView: NSView {
+    var onWindowChange: ((NSWindow?) -> Void)?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        onWindowChange?(window)
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        onWindowChange?(newWindow)
+    }
+
+    func publishCurrentWindow() {
+        onWindowChange?(window)
+    }
+}
+#endif
 
 private extension View {
     @ViewBuilder

--- a/VVTerm/Features/TerminalSessions/UI/Tabs/ConnectionTabsView.swift
+++ b/VVTerm/Features/TerminalSessions/UI/Tabs/ConnectionTabsView.swift
@@ -171,6 +171,13 @@ struct ConnectionTerminalContainer: View {
                 if let currentId = selectedTabId, !serverTabs.contains(where: { $0.id == currentId }) {
                     selectedTabIdBinding.wrappedValue = serverTabs.first?.id
                 }
+                if selectedView != "terminal" || serverTabs.isEmpty {
+                    clearTerminalFocusIfNeeded()
+                }
+            }
+            .onChange(of: selectedView) { newValue in
+                guard newValue != "terminal" else { return }
+                clearTerminalFocusIfNeeded()
             }
             .onChange(of: isZenModeEnabled) { newValue in
                 if !newValue {
@@ -304,6 +311,18 @@ struct ConnectionTerminalContainer: View {
                 UserDefaults.standard.set(resolved.toHex(), forKey: "terminalBackgroundColor")
             }
         }
+    }
+
+    private func clearTerminalFocusIfNeeded() {
+        #if os(macOS)
+        let serverId = server.id
+        DispatchQueue.main.async {
+            guard TerminalTabManager.shared.selectedViewByServer[serverId] != "terminal" else { return }
+            guard let window = NSApp.keyWindow,
+                  window.firstResponder is GhosttyTerminalView else { return }
+            window.makeFirstResponder(nil)
+        }
+        #endif
     }
 
     // MARK: - Toolbar Items (macOS)

--- a/VVTerm/Features/TerminalSessions/UI/Terminal/SSHTerminalWrapper.swift
+++ b/VVTerm/Features/TerminalSessions/UI/Terminal/SSHTerminalWrapper.swift
@@ -499,7 +499,7 @@ struct SSHTerminalWrapper: NSViewRepresentable {
                           context.coordinator.wasActive,
                           let window = terminalView.window,
                           window.firstResponder !== terminalView else { return }
-                        window.makeFirstResponder(terminalView)
+                    window.makeFirstResponder(terminalView)
                 }
             }
         }

--- a/VVTerm/Features/TerminalSessions/UI/Terminal/SSHTerminalWrapper.swift
+++ b/VVTerm/Features/TerminalSessions/UI/Terminal/SSHTerminalWrapper.swift
@@ -481,11 +481,26 @@ struct SSHTerminalWrapper: NSViewRepresentable {
             return
         }
 
-        // Ensure terminal has focus
         if let scrollView = nsView as? TerminalScrollView {
             let terminalView = scrollView.surfaceView
-            if let window = nsView.window, window.firstResponder != terminalView {
-                window.makeFirstResponder(terminalView)
+
+            let wasActive = context.coordinator.wasActive
+            context.coordinator.wasActive = isActive
+            context.coordinator.focusRequestID &+= 1
+
+            let currentWindowIdentity = nsView.window.map(ObjectIdentifier.init)
+            let didAttachToWindow = currentWindowIdentity != nil && currentWindowIdentity != context.coordinator.lastWindowIdentity
+            context.coordinator.lastWindowIdentity = currentWindowIdentity
+
+            if isActive && (!wasActive || didAttachToWindow) {
+                let focusRequestID = context.coordinator.focusRequestID
+                DispatchQueue.main.async {
+                    guard context.coordinator.focusRequestID == focusRequestID,
+                          context.coordinator.wasActive,
+                          let window = terminalView.window,
+                          window.firstResponder !== terminalView else { return }
+                        window.makeFirstResponder(terminalView)
+                }
             }
         }
     }
@@ -510,6 +525,9 @@ struct SSHTerminalWrapper: NSViewRepresentable {
 
         /// If true, this coordinator is reusing an existing terminal and should NOT cleanup on deinit
         var isReusingTerminal = false
+        var wasActive = false
+        var lastWindowIdentity: ObjectIdentifier?
+        var focusRequestID: UInt = 0
 
         init(
             server: Server,

--- a/VVTerm/GhosttyTerminal/GhosttyTerminalView+macOS.swift
+++ b/VVTerm/GhosttyTerminal/GhosttyTerminalView+macOS.swift
@@ -502,11 +502,23 @@ class GhosttyTerminalView: NSView, NSUserInterfaceValidations {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let isFirstResponder = window?.firstResponder === self
+
         switch true {
-        case MacTerminalShortcut.paste.matches(event):
+        case MacTerminalShortcutRouting.shouldHandle(
+            MacTerminalShortcut.paste,
+            keyCode: event.keyCode,
+            modifiers: event.modifierFlags,
+            isFirstResponder: isFirstResponder
+        ):
             paste(nil)
             return true
-        case MacTerminalShortcut.copy.matches(event):
+        case MacTerminalShortcutRouting.shouldHandle(
+            MacTerminalShortcut.copy,
+            keyCode: event.keyCode,
+            modifiers: event.modifierFlags,
+            isFirstResponder: isFirstResponder
+        ):
             copy(nil)
             return true
         default:

--- a/VVTerm/GhosttyTerminal/MacKeyboardShortcut.swift
+++ b/VVTerm/GhosttyTerminal/MacKeyboardShortcut.swift
@@ -32,4 +32,15 @@ enum MacTerminalShortcut {
     static let richPaste = MacKeyboardShortcut(key: .v, modifiers: .control)!
     static let toggleVoiceRecording = MacKeyboardShortcut(key: .m, modifiers: [.command, .shift])!
 }
+
+enum MacTerminalShortcutRouting {
+    static func shouldHandle(
+        _ shortcut: MacKeyboardShortcut,
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags,
+        isFirstResponder: Bool
+    ) -> Bool {
+        isFirstResponder && shortcut.matches(keyCode: keyCode, modifiers: modifiers)
+    }
+}
 #endif

--- a/VVTerm/GhosttyTerminal/TerminalScrollView.swift
+++ b/VVTerm/GhosttyTerminal/TerminalScrollView.swift
@@ -149,7 +149,9 @@ class TerminalScrollView: NSView, NSUserInterfaceValidations {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        ensureSurfaceViewIsFirstResponder()
+        guard window?.firstResponder === surfaceView else {
+            return super.performKeyEquivalent(with: event)
+        }
         if surfaceView.performKeyEquivalent(with: event) {
             return true
         }
@@ -157,12 +159,12 @@ class TerminalScrollView: NSView, NSUserInterfaceValidations {
     }
 
     @objc func copy(_ sender: Any?) {
-        ensureSurfaceViewIsFirstResponder()
+        guard window?.firstResponder === surfaceView else { return }
         surfaceView.copy(sender)
     }
 
     @objc func paste(_ sender: Any?) {
-        ensureSurfaceViewIsFirstResponder()
+        guard window?.firstResponder === surfaceView else { return }
         surfaceView.paste(sender)
     }
 

--- a/VVTermTests/MacKeyboardShortcutTests.swift
+++ b/VVTermTests/MacKeyboardShortcutTests.swift
@@ -38,5 +38,45 @@ struct MacKeyboardShortcutTests {
     func neighboringKeyDoesNotMatchShortcut() {
         #expect(MacTerminalShortcut.paste.matches(keyCode: Ghostty.Input.Key.c.keyCode!, modifiers: .command) == false)
     }
+
+    @Test
+    func commandVPasteRequiresFirstResponderOwnership() {
+        #expect(
+            MacTerminalShortcutRouting.shouldHandle(
+                MacTerminalShortcut.paste,
+                keyCode: Ghostty.Input.Key.v.keyCode!,
+                modifiers: .command,
+                isFirstResponder: true
+            )
+        )
+        #expect(
+            MacTerminalShortcutRouting.shouldHandle(
+                MacTerminalShortcut.paste,
+                keyCode: Ghostty.Input.Key.v.keyCode!,
+                modifiers: .command,
+                isFirstResponder: false
+            ) == false
+        )
+    }
+
+    @Test
+    func commandCCopyRequiresFirstResponderOwnership() {
+        #expect(
+            MacTerminalShortcutRouting.shouldHandle(
+                MacTerminalShortcut.copy,
+                keyCode: Ghostty.Input.Key.c.keyCode!,
+                modifiers: .command,
+                isFirstResponder: true
+            )
+        )
+        #expect(
+            MacTerminalShortcutRouting.shouldHandle(
+                MacTerminalShortcut.copy,
+                keyCode: Ghostty.Input.Key.c.keyCode!,
+                modifiers: .command,
+                isFirstResponder: false
+            ) == false
+        )
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- stop hidden macOS terminal views from promoting themselves to first responder while handling copy/paste shortcuts
- restore terminal focus only through the active tab or pane wrappers, and revalidate deferred focus requests against the current selected tab before they run
- clear stale terminal responder ownership when leaving the terminal view so copy and paste stay aligned with the visible target

## Verification
- built the macOS app with code signing disabled via `xcodebuild -scheme VVTerm -destination \"platform=macOS\" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=\"\" build`
- added macOS shortcut routing regression coverage in `VVTermTests/MacKeyboardShortcutTests.swift`