### PR TITLE
Fix macOS terminal font defaults and fallback handling

### DIFF
--- a/VVTerm/App/VVTermApp.swift
+++ b/VVTerm/App/VVTermApp.swift
@@ -39,8 +39,8 @@ struct VVTermApp: App {
     @AppStorage(PrivacyModeSettings.enabledKey) private var privacyModeEnabled = false
 
     // Terminal settings to watch for changes
-    @AppStorage("terminalFontName") private var terminalFontName = "JetBrainsMono Nerd Font"
-    @AppStorage("terminalFontSize") private var terminalFontSize = 8.0
+    @AppStorage(TerminalDefaults.fontNameKey) private var terminalFontName = TerminalDefaults.defaultFontName
+    @AppStorage(TerminalDefaults.fontSizeKey) private var terminalFontSize = TerminalDefaults.defaultFontSize
     @AppStorage(CloudKitSyncConstants.terminalThemeNameKey) private var terminalThemeName = "Aizen Dark"
     @AppStorage(CloudKitSyncConstants.terminalThemeNameLightKey) private var terminalThemeNameLight = "Aizen Light"
     @AppStorage(CloudKitSyncConstants.terminalUsePerAppearanceThemeKey) private var usePerAppearanceTheme = true

--- a/VVTerm/Core/Terminal/TerminalDefaults.swift
+++ b/VVTerm/Core/Terminal/TerminalDefaults.swift
@@ -11,13 +11,24 @@ import AppKit
 #endif
 
 enum TerminalDefaults {
-    private static let fontSizeKey = "terminalFontSize"
+    static let fontNameKey = "terminalFontName"
+    static let fontSizeKey = "terminalFontSize"
+    static let legacyDefaultFontName = "JetBrainsMono Nerd Font"
+    static let legacyDefaultFontSize = 12.0
+    #if os(macOS)
+    static let defaultPrimaryFontName = "Menlo"
+    static let macOSFallbackFontFamilies = [
+        "Apple SD Gothic Neo",
+        legacyDefaultFontName
+    ]
+    #endif
 
     static func applyIfNeeded() {
-        let defaults = UserDefaults.standard
-        if defaults.object(forKey: fontSizeKey) == nil {
-            defaults.set(defaultFontSize, forKey: fontSizeKey)
-        }
+        applyIfNeeded(defaults: .standard)
+    }
+
+    static func applyIfNeeded(defaults: UserDefaults) {
+        seedFontDefaultsIfNeeded(defaults: defaults)
 
         if defaults.object(forKey: ImagePasteBehavior.userDefaultsKey) == nil {
             let imagePasteBehavior = RichClipboardSettings.resolvedImagePasteBehavior(defaults: defaults)
@@ -41,4 +52,76 @@ enum TerminalDefaults {
         return 10.0
         #endif
     }
+
+    #if os(macOS)
+    static var defaultFontName: String {
+        defaultPrimaryFontName
+    }
+    #else
+    static var defaultFontName: String {
+        legacyDefaultFontName
+    }
+    #endif
+
+    private static func seedFontDefaultsIfNeeded(defaults: UserDefaults) {
+        #if os(macOS)
+        seedMacOSFontDefaultsIfNeeded(defaults: defaults)
+        #else
+        if let fontName = defaults.string(forKey: fontNameKey) {
+            if fontName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                defaults.set(defaultFontName, forKey: fontNameKey)
+            }
+        } else {
+            defaults.set(defaultFontName, forKey: fontNameKey)
+        }
+
+        if defaults.object(forKey: fontSizeKey) == nil {
+            defaults.set(defaultFontSize, forKey: fontSizeKey)
+        }
+        #endif
+    }
+
+    #if os(macOS)
+    private static func seedMacOSFontDefaultsIfNeeded(defaults: UserDefaults) {
+        let storedFontName = defaults.string(forKey: fontNameKey)
+        let normalizedStoredFontName = storedFontName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedFontSize = defaults.object(forKey: fontSizeKey) as? Double
+
+        if normalizedStoredFontName == nil || normalizedStoredFontName?.isEmpty == true {
+            defaults.set(defaultPrimaryFontName, forKey: fontNameKey)
+        }
+
+        if storedFontSize == nil {
+            defaults.set(defaultFontSize, forKey: fontSizeKey)
+        }
+
+        guard let resolvedFontName = defaults.string(forKey: fontNameKey)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !resolvedFontName.isEmpty else {
+            return
+        }
+
+        let normalizedFontName = normalizedMacOSFontName(
+            storedFontName: resolvedFontName,
+            fontValidator: { isValidMacOSFixedPitchFamily(named: $0) }
+        )
+
+        if normalizedFontName != resolvedFontName {
+            defaults.set(normalizedFontName, forKey: fontNameKey)
+        }
+    }
+
+    static func normalizedMacOSFontName(
+        storedFontName: String,
+        fontValidator: (String) -> Bool
+    ) -> String {
+        let isValidFixedPitchFont = fontValidator(storedFontName)
+
+        return isValidFixedPitchFont ? storedFontName : defaultPrimaryFontName
+    }
+
+    private static func isValidMacOSFixedPitchFamily(named familyName: String) -> Bool {
+        guard let font = NSFont(name: familyName, size: 12) else { return false }
+        return font.isFixedPitch
+    }
+    #endif
 }

--- a/VVTerm/Core/Terminal/TerminalDefaults.swift
+++ b/VVTerm/Core/Terminal/TerminalDefaults.swift
@@ -14,7 +14,6 @@ enum TerminalDefaults {
     static let fontNameKey = "terminalFontName"
     static let fontSizeKey = "terminalFontSize"
     static let legacyDefaultFontName = "JetBrainsMono Nerd Font"
-    static let legacyDefaultFontSize = 12.0
     #if os(macOS)
     static let defaultPrimaryFontName = "Menlo"
     static let macOSFallbackFontFamilies = [

--- a/VVTerm/Core/Terminal/TerminalDefaults.swift
+++ b/VVTerm/Core/Terminal/TerminalDefaults.swift
@@ -101,7 +101,7 @@ enum TerminalDefaults {
 
         let normalizedFontName = normalizedMacOSFontName(
             storedFontName: resolvedFontName,
-            fontValidator: { isValidMacOSFixedPitchFamily(named: $0) }
+            fontAvailability: { isAvailableMacOSFont(named: $0) }
         )
 
         if normalizedFontName != resolvedFontName {
@@ -111,16 +111,13 @@ enum TerminalDefaults {
 
     static func normalizedMacOSFontName(
         storedFontName: String,
-        fontValidator: (String) -> Bool
+        fontAvailability: (String) -> Bool
     ) -> String {
-        let isValidFixedPitchFont = fontValidator(storedFontName)
-
-        return isValidFixedPitchFont ? storedFontName : defaultPrimaryFontName
+        fontAvailability(storedFontName) ? storedFontName : defaultPrimaryFontName
     }
 
-    private static func isValidMacOSFixedPitchFamily(named familyName: String) -> Bool {
-        guard let font = NSFont(name: familyName, size: 12) else { return false }
-        return font.isFixedPitch
+    private static func isAvailableMacOSFont(named fontName: String) -> Bool {
+        NSFont(name: fontName, size: 12) != nil
     }
     #endif
 }

--- a/VVTerm/Features/Settings/UI/SettingsView.swift
+++ b/VVTerm/Features/Settings/UI/SettingsView.swift
@@ -34,8 +34,8 @@ enum SettingsSelection: Hashable {
 // MARK: - Settings View
 
 struct SettingsView: View {
-    @AppStorage("terminalFontName") private var terminalFontName = "JetBrainsMono Nerd Font"
-    @AppStorage("terminalFontSize") private var terminalFontSize = 8.0
+    @AppStorage(TerminalDefaults.fontNameKey) private var terminalFontName = TerminalDefaults.defaultFontName
+    @AppStorage(TerminalDefaults.fontSizeKey) private var terminalFontSize = TerminalDefaults.defaultFontSize
 
     @State private var selection: SettingsSelection? = .pro
     @StateObject private var storeManager = StoreManager.shared

--- a/VVTerm/Features/Settings/UI/TerminalSettingsView.swift
+++ b/VVTerm/Features/Settings/UI/TerminalSettingsView.swift
@@ -389,13 +389,27 @@ struct TerminalSettingsView: View {
         }
         .onAppear {
             if availableFonts.isEmpty {
-                availableFonts = loadSystemFonts()
+                availableFonts = Self.fontListEnsuringCurrentFont(
+                    systemFonts: loadSystemFonts(),
+                    currentFontName: fontName
+                )
             }
             if builtInThemeNames.isEmpty {
                 builtInThemeNames = TerminalThemeManager.builtInThemeNames()
             }
             ensureThemeSelectionIsValid()
         }
+    }
+
+    /// Ensures the current primary font appears in the picker list.
+    /// If the stored font name is missing from the system font list
+    /// (e.g., a previously-installed font was removed), it is prepended
+    /// so the Picker can display the current selection without breaking.
+    static func fontListEnsuringCurrentFont(systemFonts: [String], currentFontName: String) -> [String] {
+        let trimmed = currentFontName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return systemFonts }
+        guard !systemFonts.contains(trimmed) else { return systemFonts }
+        return [trimmed] + systemFonts
     }
 
     #if os(macOS)

--- a/VVTerm/GhosttyTerminal/Ghostty.App.swift
+++ b/VVTerm/GhosttyTerminal/Ghostty.App.swift
@@ -65,9 +65,17 @@ extension Ghostty {
             return families
         }
 
+        static func escapedFontFamilyValue(_ family: String) -> String {
+            family
+                .replacingOccurrences(of: "\r", with: "")
+                .replacingOccurrences(of: "\n", with: "")
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+        }
+
         static func fontFamilyLines(primaryFamily: String) -> String {
             sanitizedFontFamilies(primaryFamily: primaryFamily)
-                .map { "font-family = \"\($0)\"" }
+                .map { "font-family = \"\(escapedFontFamilyValue($0))\"" }
                 .joined(separator: "\n")
         }
 

--- a/VVTerm/GhosttyTerminal/Ghostty.App.swift
+++ b/VVTerm/GhosttyTerminal/Ghostty.App.swift
@@ -44,6 +44,74 @@ enum Ghostty {
 // MARK: - Ghostty.App
 
 extension Ghostty {
+    enum ConfigBuilder {
+        static func sanitizedFontFamilies(primaryFamily: String) -> [String] {
+            #if os(macOS)
+            let candidates = [primaryFamily] + TerminalDefaults.macOSFallbackFontFamilies
+            #else
+            let candidates = [primaryFamily]
+            #endif
+
+            var seen = Set<String>()
+            var families: [String] = []
+
+            for candidate in candidates {
+                let family = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !family.isEmpty else { continue }
+                guard seen.insert(family).inserted else { continue }
+                families.append(family)
+            }
+
+            return families
+        }
+
+        static func fontFamilyLines(primaryFamily: String) -> String {
+            sanitizedFontFamilies(primaryFamily: primaryFamily)
+                .map { "font-family = \"\($0)\"" }
+                .joined(separator: "\n")
+        }
+
+        static func configContent(
+            primaryFontFamily: String,
+            fontSize: Double,
+            shellName: String,
+            themeName: String
+        ) -> String {
+            """
+            \(fontFamilyLines(primaryFamily: primaryFontFamily))
+            font-size = \(Int(fontSize))
+            window-inherit-font-size = false
+            window-padding-balance = false
+            window-padding-x = 0
+            window-padding-y = 0
+            window-padding-color = extend-always
+
+            # Enable shell integration (resources dir auto-detected from app bundle)
+            shell-integration = \(shellName)
+            shell-integration-features = no-cursor,sudo,title
+
+            # Cursor
+            cursor-style-blink = true
+
+            theme = \(themeName)
+
+            # Disable audible bell
+            audible-bell = false
+
+            # Limit scrollback to prevent unbounded memory growth
+            # 10000 lines is plenty for most use cases (~5-10MB)
+            scrollback-limit = 10000
+
+            # Faster scroll speed (especially for iOS touch)
+            mouse-scroll-multiplier = 3
+
+            # Custom keybinds
+            keybind = shift+enter=text:\\n
+
+            """
+        }
+    }
+
     /// Minimal wrapper for ghostty_app_t lifecycle management
     @MainActor
     class App: ObservableObject {
@@ -74,8 +142,8 @@ extension Ghostty {
 
         // MARK: - Terminal Settings from AppStorage
 
-        @AppStorage("terminalFontName") private var terminalFontName = "JetBrainsMono Nerd Font"
-        @AppStorage("terminalFontSize") private var terminalFontSize = 8.0
+        @AppStorage(TerminalDefaults.fontNameKey) private var terminalFontName = TerminalDefaults.defaultFontName
+        @AppStorage(TerminalDefaults.fontSizeKey) private var terminalFontSize = TerminalDefaults.defaultFontSize
         @AppStorage(CloudKitSyncConstants.terminalThemeNameKey) private var terminalThemeName = "Aizen Dark"
         @AppStorage(CloudKitSyncConstants.terminalThemeNameLightKey) private var terminalThemeNameLight = "Aizen Light"
         @AppStorage(CloudKitSyncConstants.terminalUsePerAppearanceThemeKey) private var usePerAppearanceTheme = true
@@ -341,38 +409,12 @@ extension Ghostty {
                 let shellName = (shell as NSString).lastPathComponent
 
                 // Create config with font settings, shell integration, and theme
-                let configContent = """
-                font-family = \(terminalFontName)
-                font-size = \(Int(terminalFontSize))
-                window-inherit-font-size = false
-                window-padding-balance = false
-                window-padding-x = 0
-                window-padding-y = 0
-                window-padding-color = extend-always
-
-                # Enable shell integration (resources dir auto-detected from app bundle)
-                shell-integration = \(shellName)
-                shell-integration-features = no-cursor,sudo,title
-
-                # Cursor
-                cursor-style-blink = true
-
-                theme = \(effectiveThemeName)
-
-                # Disable audible bell
-                audible-bell = false
-
-                # Limit scrollback to prevent unbounded memory growth
-                # 10000 lines is plenty for most use cases (~5-10MB)
-                scrollback-limit = 10000
-
-                # Faster scroll speed (especially for iOS touch)
-                mouse-scroll-multiplier = 3
-
-                # Custom keybinds
-                keybind = shift+enter=text:\\n
-
-                """
+                let configContent = ConfigBuilder.configContent(
+                    primaryFontFamily: terminalFontName,
+                    fontSize: terminalFontSize,
+                    shellName: shellName,
+                    themeName: effectiveThemeName
+                )
 
                 Ghostty.logger.info("Loading Ghostty theme: \(self.effectiveThemeName)")
 

--- a/VVTerm/GhosttyTerminal/GhosttyRenderingSetup.swift
+++ b/VVTerm/GhosttyTerminal/GhosttyRenderingSetup.swift
@@ -22,8 +22,8 @@ class GhosttyRenderingSetup {
 
     // MARK: - Terminal Settings from AppStorage
 
-    @AppStorage("terminalFontName") private var terminalFontName = "JetBrainsMono Nerd Font"
-    @AppStorage("terminalFontSize") private var terminalFontSize = 8.0
+    @AppStorage(TerminalDefaults.fontNameKey) private var terminalFontName = TerminalDefaults.defaultFontName
+    @AppStorage(TerminalDefaults.fontSizeKey) private var terminalFontSize = TerminalDefaults.defaultFontSize
     @AppStorage("terminalBackgroundColor") private var terminalBackgroundColor = "#1e1e2e"
     @AppStorage("terminalForegroundColor") private var terminalForegroundColor = "#cdd6f4"
     @AppStorage("terminalCursorColor") private var terminalCursorColor = "#f5e0dc"

--- a/VVTermTests/GhosttyConfigBuilderTests.swift
+++ b/VVTermTests/GhosttyConfigBuilderTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import VVTerm
+
+struct GhosttyConfigBuilderTests {
+    #if os(macOS)
+    @Test
+    func macOSFontFamilyLinesUseDeterministicFallbackStack() {
+        let lines = Ghostty.ConfigBuilder.fontFamilyLines(primaryFamily: "Menlo")
+            .split(separator: "\n")
+            .map(String.init)
+
+        #expect(lines == [
+            "font-family = \"Menlo\"",
+            "font-family = \"Apple SD Gothic Neo\"",
+            "font-family = \"JetBrainsMono Nerd Font\""
+        ])
+    }
+
+    @Test
+    func macOSFontFamilyLinesTrimWhitespaceAndDeduplicateFamilies() {
+        let appleFallback = TerminalDefaults.macOSFallbackFontFamilies[0]
+        let lines = Ghostty.ConfigBuilder.fontFamilyLines(primaryFamily: "  \(appleFallback)  ")
+            .split(separator: "\n")
+            .map(String.init)
+
+        #expect(lines == [
+            "font-family = \"Apple SD Gothic Neo\"",
+            "font-family = \"JetBrainsMono Nerd Font\""
+        ])
+    }
+    #endif
+
+    @Test
+    func fontFamilyLinesIgnoreBlankPrimaryFamily() {
+        let lines = Ghostty.ConfigBuilder.fontFamilyLines(primaryFamily: "   \n  ")
+            .split(separator: "\n")
+            .map(String.init)
+
+        #if os(macOS)
+        #expect(lines == [
+            "font-family = \"Apple SD Gothic Neo\"",
+            "font-family = \"JetBrainsMono Nerd Font\""
+        ])
+        #else
+        #expect(lines.isEmpty)
+        #endif
+    }
+
+    #if os(iOS)
+    @Test
+    func iOSConfigContentPreservesSingleFamilyBehavior() {
+        let content = Ghostty.ConfigBuilder.configContent(
+            primaryFontFamily: "  JetBrainsMono Nerd Font  ",
+            fontSize: 9,
+            shellName: "zsh",
+            themeName: "Aizen Dark"
+        )
+
+        let fontFamilyLines = content
+            .split(separator: "\n")
+            .map(String.init)
+            .filter { $0.hasPrefix("font-family =") }
+
+        #expect(fontFamilyLines == ["font-family = \"JetBrainsMono Nerd Font\""])
+    }
+    #endif
+
+    @Test
+    func configContentKeepsNonFontLinesStable() {
+        let content = Ghostty.ConfigBuilder.configContent(
+            primaryFontFamily: "Menlo",
+            fontSize: 13,
+            shellName: "fish",
+            themeName: "Aizen Light"
+        )
+
+        #expect(content.contains("font-size = 13"))
+        #expect(content.contains("window-inherit-font-size = false"))
+        #expect(content.contains("shell-integration = fish"))
+        #expect(content.contains("theme = Aizen Light"))
+        #expect(content.contains("keybind = shift+enter=text:\\n"))
+    }
+}

--- a/VVTermTests/GhosttyConfigBuilderTests.swift
+++ b/VVTermTests/GhosttyConfigBuilderTests.swift
@@ -47,6 +47,15 @@ struct GhosttyConfigBuilderTests {
         #endif
     }
 
+    @Test
+    func fontFamilyLinesEscapeQuotesBackslashesAndNewlines() {
+        let lines = Ghostty.ConfigBuilder.fontFamilyLines(primaryFamily: "A\"B\\C\nD\rE")
+            .split(separator: "\n")
+            .map(String.init)
+
+        #expect(lines.first == "font-family = \"A\\\"B\\\\CDE\"")
+    }
+
     #if os(iOS)
     @Test
     func iOSConfigContentPreservesSingleFamilyBehavior() {

--- a/VVTermTests/TerminalDefaultsTests.swift
+++ b/VVTermTests/TerminalDefaultsTests.swift
@@ -76,7 +76,7 @@ struct TerminalDefaultsTests {
         #if os(macOS)
         let normalizedFontName = TerminalDefaults.normalizedMacOSFontName(
             storedFontName: TerminalDefaults.legacyDefaultFontName,
-            fontValidator: { _ in true }
+            fontAvailability: { _ in true }
         )
 
         #expect(normalizedFontName == TerminalDefaults.legacyDefaultFontName)
@@ -90,12 +90,26 @@ struct TerminalDefaultsTests {
         #if os(macOS)
         let normalizedFontName = TerminalDefaults.normalizedMacOSFontName(
             storedFontName: TerminalDefaults.legacyDefaultFontName,
-            fontValidator: { _ in false }
+            fontAvailability: { _ in false }
         )
 
         #expect(normalizedFontName == TerminalDefaults.defaultPrimaryFontName)
         #else
         throw Skip("macOS-only legacy font normalization")
+        #endif
+    }
+
+    @Test
+    func applyIfNeededPreservesInstalledMacOSFontsDuringNormalization() throws {
+        #if os(macOS)
+        let normalizedFontName = TerminalDefaults.normalizedMacOSFontName(
+            storedFontName: "Installed But Misclassified Font",
+            fontAvailability: { _ in true }
+        )
+
+        #expect(normalizedFontName == "Installed But Misclassified Font")
+        #else
+        throw Skip("macOS-only font normalization")
         #endif
     }
 

--- a/VVTermTests/TerminalDefaultsTests.swift
+++ b/VVTermTests/TerminalDefaultsTests.swift
@@ -17,7 +17,6 @@ struct TerminalDefaultsTests {
         #expect(TerminalDefaults.defaultPrimaryFontName == "Menlo")
         #expect(TerminalDefaults.defaultFontSize == 12.0)
         #expect(TerminalDefaults.legacyDefaultFontName == "JetBrainsMono Nerd Font")
-        #expect(TerminalDefaults.legacyDefaultFontSize == 12.0)
         #expect(
             TerminalDefaults.macOSFallbackFontFamilies == ["Apple SD Gothic Neo", "JetBrainsMono Nerd Font"]
         )

--- a/VVTermTests/TerminalDefaultsTests.swift
+++ b/VVTermTests/TerminalDefaultsTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import VVTerm
+
+struct TerminalDefaultsTests {
+    private func makeDefaults(testName: String = #function) -> UserDefaults {
+        let suiteName = "TerminalDefaultsTests.\(testName)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    @Test
+    func macOSDefaultsExposeMenloAndTwelvePointSize() throws {
+        #if os(macOS)
+        #expect(TerminalDefaults.defaultFontName == "Menlo")
+        #expect(TerminalDefaults.defaultPrimaryFontName == "Menlo")
+        #expect(TerminalDefaults.defaultFontSize == 12.0)
+        #expect(TerminalDefaults.legacyDefaultFontName == "JetBrainsMono Nerd Font")
+        #expect(TerminalDefaults.legacyDefaultFontSize == 12.0)
+        #expect(
+            TerminalDefaults.macOSFallbackFontFamilies == ["Apple SD Gothic Neo", "JetBrainsMono Nerd Font"]
+        )
+        #else
+        throw Skip("macOS-only default font policy")
+        #endif
+    }
+
+    @Test
+    func applyIfNeededSeedsUnsetFontDefaults() {
+        let defaults = makeDefaults()
+
+        TerminalDefaults.applyIfNeeded(defaults: defaults)
+
+        #if os(macOS)
+        #expect(defaults.string(forKey: TerminalDefaults.fontNameKey) == "Menlo")
+        #expect(defaults.object(forKey: TerminalDefaults.fontSizeKey) as? Double == 12.0)
+        #else
+        #expect(defaults.string(forKey: TerminalDefaults.fontNameKey) == TerminalDefaults.defaultFontName)
+        #expect(defaults.object(forKey: TerminalDefaults.fontSizeKey) as? Double == TerminalDefaults.defaultFontSize)
+        #endif
+        #expect(defaults.object(forKey: ImagePasteBehavior.userDefaultsKey) as? String == ImagePasteBehavior.askOnce.rawValue)
+    }
+
+    @Test
+    func applyIfNeededNormalizesBlankFontNameWithoutOverwritingExistingFontSize() {
+        let defaults = makeDefaults()
+
+        defaults.set("   \n", forKey: TerminalDefaults.fontNameKey)
+        defaults.set(14.0, forKey: TerminalDefaults.fontSizeKey)
+
+        TerminalDefaults.applyIfNeeded(defaults: defaults)
+
+        #expect(defaults.string(forKey: TerminalDefaults.fontNameKey) == TerminalDefaults.defaultFontName)
+        #expect(defaults.object(forKey: TerminalDefaults.fontSizeKey) as? Double == 14.0)
+    }
+
+    @Test
+    func applyIfNeededPreservesCustomMacOSFontValues() throws {
+        #if os(macOS)
+        let defaults = makeDefaults()
+
+        defaults.set("Menlo", forKey: TerminalDefaults.fontNameKey)
+        defaults.set(15.0, forKey: TerminalDefaults.fontSizeKey)
+
+        TerminalDefaults.applyIfNeeded(defaults: defaults)
+
+        #expect(defaults.string(forKey: TerminalDefaults.fontNameKey) == "Menlo")
+        #expect(defaults.object(forKey: TerminalDefaults.fontSizeKey) as? Double == 15.0)
+        #else
+        throw Skip("macOS-only migration policy")
+        #endif
+    }
+
+    @Test
+    func applyIfNeededPreservesExactLegacyMacOSFontValues() throws {
+        #if os(macOS)
+        let normalizedFontName = TerminalDefaults.normalizedMacOSFontName(
+            storedFontName: TerminalDefaults.legacyDefaultFontName,
+            fontValidator: { _ in true }
+        )
+
+        #expect(normalizedFontName == TerminalDefaults.legacyDefaultFontName)
+        #else
+        throw Skip("macOS-only legacy font preservation")
+        #endif
+    }
+
+    @Test
+    func applyIfNeededNormalizesExactLegacyMacOSFontValuesWhenFontIsUnavailable() throws {
+        #if os(macOS)
+        let normalizedFontName = TerminalDefaults.normalizedMacOSFontName(
+            storedFontName: TerminalDefaults.legacyDefaultFontName,
+            fontValidator: { _ in false }
+        )
+
+        #expect(normalizedFontName == TerminalDefaults.defaultPrimaryFontName)
+        #else
+        throw Skip("macOS-only legacy font normalization")
+        #endif
+    }
+
+    @Test
+    func applyIfNeededNormalizesInvalidStoredMacOSFontName() throws {
+        #if os(macOS)
+        let defaults = makeDefaults()
+
+        defaults.set("DefinitelyNotARealFixedPitchFont", forKey: TerminalDefaults.fontNameKey)
+        defaults.set(16.0, forKey: TerminalDefaults.fontSizeKey)
+
+        TerminalDefaults.applyIfNeeded(defaults: defaults)
+
+        #expect(defaults.string(forKey: TerminalDefaults.fontNameKey) == TerminalDefaults.defaultPrimaryFontName)
+        #expect(defaults.object(forKey: TerminalDefaults.fontSizeKey) as? Double == 16.0)
+        #else
+        throw Skip("macOS-only migration policy")
+        #endif
+    }
+}

--- a/VVTermTests/TerminalFontSettingsTests.swift
+++ b/VVTermTests/TerminalFontSettingsTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import VVTerm
+
+struct TerminalFontSettingsTests {
+
+    // MARK: - Fresh default source
+
+    @Test
+    func freshMacOSDefaultsResolveToMenlo() throws {
+        #if os(macOS)
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+
+        TerminalDefaults.applyIfNeeded(defaults: defaults)
+
+        let seededName = defaults.string(forKey: TerminalDefaults.fontNameKey)
+        #expect(seededName == "Menlo")
+
+        // The Settings @AppStorage initializer uses TerminalDefaults.defaultFontName
+        // as its in-memory default, so even before applyIfNeeded runs it would
+        // resolve to "Menlo" on macOS.
+        #expect(TerminalDefaults.defaultFontName == "Menlo")
+        #else
+        throw Skip("macOS-only fresh default source check")
+        #endif
+    }
+
+    @Test
+    func freshMacOSFontSizeIsTwelvePoints() throws {
+        #if os(macOS)
+        #expect(TerminalDefaults.defaultFontSize == 12.0)
+        #else
+        throw Skip("macOS-only default font size check")
+        #endif
+    }
+
+    // MARK: - Missing-font injection
+
+    @Test
+    func fontListPrependsCurrentFontWhenMissing() {
+        let systemFonts = ["Andale Mono", "Courier", "Monaco"]
+        let result = TerminalSettingsView.fontListEnsuringCurrentFont(
+            systemFonts: systemFonts,
+            currentFontName: "Menlo"
+        )
+
+        #expect(result.first == "Menlo")
+        #expect(result.count == systemFonts.count + 1)
+        // Original order preserved after the prepended entry
+        #expect(Array(result.dropFirst()) == systemFonts)
+    }
+
+    @Test
+    func fontListUnchangedWhenCurrentFontAlreadyPresent() {
+        let systemFonts = ["Menlo", "Monaco", "Courier"]
+
+        let result = TerminalSettingsView.fontListEnsuringCurrentFont(
+            systemFonts: systemFonts,
+            currentFontName: "Menlo"
+        )
+
+        #expect(result == systemFonts)
+    }
+
+    @Test
+    func fontListUnchangedForBlankCurrentFont() {
+        let systemFonts = ["Menlo", "Monaco"]
+
+        let resultBlank = TerminalSettingsView.fontListEnsuringCurrentFont(
+            systemFonts: systemFonts,
+            currentFontName: ""
+        )
+        #expect(resultBlank == systemFonts)
+
+        let resultWhitespace = TerminalSettingsView.fontListEnsuringCurrentFont(
+            systemFonts: systemFonts,
+            currentFontName: "  \n  "
+        )
+        #expect(resultWhitespace == systemFonts)
+    }
+
+    @Test
+    func fontListPrependsCustomFontNotInSystemList() {
+        let systemFonts = ["Menlo", "Monaco"]
+        let result = TerminalSettingsView.fontListEnsuringCurrentFont(
+            systemFonts: systemFonts,
+            currentFontName: "MyUninstalledFont"
+        )
+
+        #expect(result == ["MyUninstalledFont", "Menlo", "Monaco"])
+    }
+
+    @Test
+    func fontListDoesNotDuplicateCaseSensitiveMatch() {
+        let systemFonts = ["Menlo", "monaco"]
+        let result = TerminalSettingsView.fontListEnsuringCurrentFont(
+            systemFonts: systemFonts,
+            currentFontName: "Menlo"
+        )
+
+        // Exact match prevents injection; no duplicate
+        #expect(result == systemFonts)
+    }
+
+    // MARK: - Fallback families are not forced as primary
+
+    @Test
+    func fallbackFamiliesAreNotDefaultPrimaryFont() throws {
+        #if os(macOS)
+        let fallbacks = TerminalDefaults.macOSFallbackFontFamilies
+
+        // The default primary font must not be any of the fallback families
+        #expect(!fallbacks.contains(TerminalDefaults.defaultFontName))
+
+        // The fallbacks themselves are "Apple SD Gothic Neo" and the legacy default
+        #expect(fallbacks.contains("Apple SD Gothic Neo"))
+        #expect(fallbacks.contains("JetBrainsMono Nerd Font"))
+        #else
+        throw Skip("macOS-only fallback family check")
+        #endif
+    }
+
+    @Test
+    func settingsDefaultFontIsNotAFallbackFamily() throws {
+        #if os(macOS)
+        // Verify that the Settings picker default is "Menlo", not a fallback
+        #expect(TerminalDefaults.defaultFontName == "Menlo")
+        #expect(TerminalDefaults.defaultFontName != "Apple SD Gothic Neo")
+        #expect(TerminalDefaults.defaultFontName != "JetBrainsMono Nerd Font")
+        #else
+        throw Skip("macOS-only primary vs fallback check")
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- Set the macOS terminal default font flow to use a stable primary font while preserving existing behavior for unchanged platforms.
- Make Ghostty font-family output deterministic for macOS fallback handling so Korean glyph rendering no longer depends on an implicit serif fallback.
- Keep the Settings font picker aligned with the runtime font value and add regression coverage for defaults, fallback generation, and settings display behavior.

## Why these files are necessary

### Core implementation
- `VVTerm/Core/Terminal/TerminalDefaults.swift`
  - This is the single source of truth for terminal font defaults.
  - The macOS default font, invalid-font normalization, and default seeding behavior all live here, so the bug cannot be fixed without updating this file.
  - It also defines the fallback family list consumed by the renderer path.

- `VVTerm/GhosttyTerminal/Ghostty.App.swift`
  - This file generates the Ghostty config content that is actually passed to the terminal engine.
  - The fix requires emitting repeated `font-family` lines in a deterministic order for macOS fallback handling.
  - Without this file, the new default/fallback policy would exist only in settings code and would never reach the terminal renderer.

- `VVTerm/Features/Settings/UI/TerminalSettingsView.swift`
  - The Settings picker needs to keep showing the currently stored primary font even when that font is temporarily missing from the enumerated system font list.
  - This is necessary to prevent the UI from drifting away from the runtime value after the new default/fallback policy is applied.

### Direct consumers of centralized defaults
- `VVTerm/App/VVTermApp.swift`
  - Watches terminal font settings and triggers config reloads.
  - Its `@AppStorage` defaults must match the centralized terminal defaults, otherwise app startup and reload behavior can still seed stale values.

- `VVTerm/Features/Settings/UI/SettingsView.swift`
  - Owns the Settings entry point and passes the stored font values into `TerminalSettingsView`.
  - It must read the same centralized defaults so a fresh macOS settings session starts from the intended primary font.

- `VVTerm/GhosttyTerminal/GhosttyRenderingSetup.swift`
  - Reads the stored font defaults when configuring the surface.
  - Even though the renderer surface still only uses font size directly, this file is a direct AppStorage consumer and needed to be aligned with the centralized defaults to avoid duplicated stale fallback values.

### Regression tests
- `VVTermTests/TerminalDefaultsTests.swift`
  - Verifies the macOS default font policy, blank-value normalization, invalid-font normalization, and preservation behavior.
  - Required because the core bug fix changes startup/defaulting behavior.

- `VVTermTests/GhosttyConfigBuilderTests.swift`
  - Verifies the generated Ghostty `font-family` stack order, quoting, and deduplication.
  - Required because the rendering fix depends on exact config output, not just stored settings.

- `VVTermTests/TerminalFontSettingsTests.swift`
  - Verifies the Settings font list keeps the current font visible when it is missing from the enumerated list.
  - Required because the UI alignment fix is easy to regress without a targeted test.

## Verification
- Added regression tests for terminal defaults, Ghostty config generation, and Settings font-list behavior.
- Verified the changed logic paths directly and confirmed no-sign local macOS builds succeed.
- Exact signed local `xcodebuild test` remains blocked by local provisioning/signing environment, which is unrelated to the code changes in this PR.
