### PR TITLE
Fix iPadOS hardware-keyboard CJK input and visual indicators (refs #18)

### DIFF
--- a/VVTerm/GhosttyTerminal/GhosttyTerminalView+iOS.swift
+++ b/VVTerm/GhosttyTerminal/GhosttyTerminalView+iOS.swift
@@ -206,7 +206,25 @@ private final class TerminalIMEProxyTextView: UITextView {
     }
 
     override func caretRect(for position: UITextPosition) -> CGRect {
-        guard super.markedTextRange != nil else { return .zero }
+        guard super.markedTextRange != nil else {
+            // Outside composition, anchor system-rendered indicators (e.g.
+            // iPadOS Caps Lock "拼音" / "ABC" IME-switch toast) near the
+            // terminal view's center instead of the proxy's (0, 0) origin
+            // where they clip against the status bar / screen edge. The
+            // proxy itself stays invisible (tintColor / textColor are
+            // clear), so no caret artifact actually renders.
+            if let owner = terminalOwner {
+                let ownerBounds = owner.bounds
+                let cellHeight = max(owner.cellSize.height, 16)
+                return CGRect(
+                    x: ownerBounds.midX,
+                    y: ownerBounds.midY,
+                    width: 1,
+                    height: cellHeight
+                )
+            }
+            return .zero
+        }
         return terminalOwner?.imeProxyCaretRect(for: position) ?? super.caretRect(for: position)
     }
 
@@ -291,8 +309,15 @@ private final class TerminalIMEProxyTextView: UITextView {
 /// - Surface lifecycle management
 @MainActor
 class GhosttyTerminalView: UIView {
-    private static let textInputContextID = "app.vivy.VVTerm.GhosttyTerminalView"
-    private static let imeProxyOffscreenFrame = CGRect(x: -10_000, y: -10_000, width: 1, height: 1)
+    // The IME proxy is a 1×1 sibling of the terminal surface. It must sit at
+    // the terminal view's origin (not offscreen at -10000, -10000) so UIKit
+    // converts our `caretRect(for:)` return value (which is in terminal-view
+    // coordinates from `ghostty_surface_ime_point`) back into the correct
+    // window position. With an offscreen origin the IME candidate window
+    // anchors thousands of points outside the screen and the user sees no
+    // input-method indicator. The proxy stays visually silent via a clear
+    // background, clear text/tint colors, and a no-op `draw(_:)`.
+    private static let imeProxyOffscreenFrame = CGRect(x: 0, y: 0, width: 1, height: 1)
     // MARK: - Properties
 
     private var ghosttyApp: ghostty_app_t?
@@ -416,7 +441,11 @@ class GhosttyTerminalView: UIView {
         textView.backgroundColor = .clear
         textView.textColor = .clear
         textView.tintColor = .clear
-        textView.alpha = 0.01
+        // alpha < 1 disqualifies the proxy from iPadOS' Caps Lock IME-switch
+        // toast ("拼音" / "ABC"). The proxy is 1×1 in the terminal view's
+        // top-left corner with a clear background, clear tint, and a no-op
+        // `draw(_:)`, so at full alpha it's still a transparent dot.
+        textView.alpha = 1.0
         textView.isOpaque = false
         textView.isUserInteractionEnabled = true
         textView.isScrollEnabled = false
@@ -781,7 +810,14 @@ class GhosttyTerminalView: UIView {
     }
 
     fileprivate var currentTextInputContextIdentifier: String? {
-        isTextInputSessionEligible ? Self.textInputContextID : nil
+        // Returning nil so iPadOS treats globe-key IME switches on this view
+        // as global events and shows the system-level "拼音" / "English"
+        // toast at screen center, matching Notes / Mail behaviour. A non-nil
+        // identifier makes iOS persist a per-view IME selection and suppress
+        // the switch toast (the switch becomes "automatic" from the system's
+        // perspective). VVTerm has no other text inputs to differentiate
+        // from, so per-view IME memory has no benefit here.
+        nil
     }
 
     fileprivate var resolvedKeyboardAppearance: UIKeyboardAppearance {

--- a/VVTerm/GhosttyTerminal/GhosttyTerminalView+iOS.swift
+++ b/VVTerm/GhosttyTerminal/GhosttyTerminalView+iOS.swift
@@ -1742,6 +1742,7 @@ class GhosttyTerminalView: UIView {
             hasAlternateModifier: key.modifierFlags.contains(.alternate),
             hasCommandModifier: key.modifierFlags.contains(.command),
             hasActiveIMEComposition: hasActiveIMEComposition,
+            isCurrentInputMethodCJK: isCurrentInputMethodCJK,
             isSystemTextInputToggleKey: key.keyCode == .keyboardCapsLock,
             hasTerminalFallbackKey: fallbackHardwareKey(for: key) != nil,
             keyProducesText: keyProducesText
@@ -2035,6 +2036,11 @@ class GhosttyTerminalView: UIView {
 
     private var currentIMEPrimaryLanguage: String? {
         imeProxyTextView.textInputMode?.primaryLanguage ?? textInputMode?.primaryLanguage
+    }
+
+    private var isCurrentInputMethodCJK: Bool {
+        guard let language = currentIMEPrimaryLanguage?.lowercased() else { return false }
+        return language.hasPrefix("zh") || language.hasPrefix("ja") || language.hasPrefix("ko")
     }
 
     private func syncIMEPreedit(_ text: String?) {

--- a/VVTerm/GhosttyTerminal/GhosttyTerminalView+iOS.swift
+++ b/VVTerm/GhosttyTerminal/GhosttyTerminalView+iOS.swift
@@ -446,6 +446,11 @@ class GhosttyTerminalView: UIView {
         // top-left corner with a clear background, clear tint, and a no-op
         // `draw(_:)`, so at full alpha it's still a transparent dot.
         textView.alpha = 1.0
+        // The proxy is a transparent IME bridge, not a user-visible text input.
+        // Hide it from VoiceOver and other accessibility clients so the empty
+        // 1×1 view at the terminal's corner does not surface as a focusable
+        // element.
+        textView.accessibilityElementsHidden = true
         textView.isOpaque = false
         textView.isUserInteractionEnabled = true
         textView.isScrollEnabled = false

--- a/VVTerm/GhosttyTerminal/TerminalHardwareTextInputRoutingPolicy.swift
+++ b/VVTerm/GhosttyTerminal/TerminalHardwareTextInputRoutingPolicy.swift
@@ -6,6 +6,7 @@ enum TerminalHardwareTextInputRoutingPolicy {
         hasAlternateModifier: Bool,
         hasCommandModifier: Bool,
         hasActiveIMEComposition: Bool,
+        isCurrentInputMethodCJK: Bool,
         isSystemTextInputToggleKey: Bool,
         hasTerminalFallbackKey: Bool,
         keyProducesText: Bool
@@ -21,6 +22,14 @@ enum TerminalHardwareTextInputRoutingPolicy {
         }
         if hasTerminalFallbackKey {
             return false
+        }
+        // When a CJK input method is active, route printable keys to the system
+        // text input before composition starts — hasActiveIMEComposition only
+        // becomes true after the first key has been accepted, so relying on it
+        // alone leaves the first keystroke on the direct terminal path and the
+        // IME never gets a chance to begin composition.
+        if isCurrentInputMethodCJK && keyProducesText {
+            return true
         }
         // Let UIKit own all remaining unmodified hardware text input so IMEs,
         // dead keys, and layout-specific composition can start reliably.

--- a/VVTermTests/TerminalHardwareTextInputRoutingPolicyTests.swift
+++ b/VVTermTests/TerminalHardwareTextInputRoutingPolicyTests.swift
@@ -10,6 +10,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: true,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: false,
                 keyProducesText: true
@@ -25,6 +26,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: true,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: false,
                 keyProducesText: true
@@ -40,6 +42,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: true,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: false,
                 keyProducesText: true
@@ -55,6 +58,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: false,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: false,
                 keyProducesText: true
@@ -70,6 +74,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: true,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: true,
                 keyProducesText: true
@@ -85,6 +90,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: false,
                 isSystemTextInputToggleKey: true,
                 hasTerminalFallbackKey: true,
                 keyProducesText: false
@@ -100,6 +106,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: true,
+                isCurrentInputMethodCJK: false,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: true,
                 keyProducesText: false
@@ -115,6 +122,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: false,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: false,
                 keyProducesText: true
@@ -126,6 +134,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: true,
                 hasCommandModifier: false,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: false,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: false,
                 keyProducesText: true
@@ -137,6 +146,7 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
                 hasAlternateModifier: false,
                 hasCommandModifier: true,
                 hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: false,
                 isSystemTextInputToggleKey: false,
                 hasTerminalFallbackKey: false,
                 keyProducesText: true

--- a/VVTermTests/TerminalHardwareTextInputRoutingPolicyTests.swift
+++ b/VVTermTests/TerminalHardwareTextInputRoutingPolicyTests.swift
@@ -153,6 +153,50 @@ struct TerminalHardwareTextInputRoutingPolicyTests {
             ) == false
         )
     }
+
+    @Test
+    func modifierKeysTakePriorityOverCJKLayout() {
+        // Lock the policy ordering: even with a CJK input method active,
+        // modifier-bearing keystrokes (Ctrl-/, Cmd-V, Alt-arrow, etc.) must
+        // stay on the direct ghostty path so terminal shortcuts never get
+        // captured by the system IME.
+        #expect(
+            TerminalHardwareTextInputRoutingPolicy.shouldRoutePressToSystemTextInput(
+                hasControlModifier: true,
+                hasAlternateModifier: false,
+                hasCommandModifier: false,
+                hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: true,
+                isSystemTextInputToggleKey: false,
+                hasTerminalFallbackKey: false,
+                keyProducesText: true
+            ) == false
+        )
+        #expect(
+            TerminalHardwareTextInputRoutingPolicy.shouldRoutePressToSystemTextInput(
+                hasControlModifier: false,
+                hasAlternateModifier: true,
+                hasCommandModifier: false,
+                hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: true,
+                isSystemTextInputToggleKey: false,
+                hasTerminalFallbackKey: false,
+                keyProducesText: true
+            ) == false
+        )
+        #expect(
+            TerminalHardwareTextInputRoutingPolicy.shouldRoutePressToSystemTextInput(
+                hasControlModifier: false,
+                hasAlternateModifier: false,
+                hasCommandModifier: true,
+                hasActiveIMEComposition: false,
+                isCurrentInputMethodCJK: true,
+                isSystemTextInputToggleKey: false,
+                hasTerminalFallbackKey: false,
+                keyProducesText: true
+            ) == false
+        )
+    }
 }
 
 struct TerminalKeyboardFocusPolicyTests {


### PR DESCRIPTION
## Summary

- Route hardware-key presses through the iPadOS system IME path when a CJK input method is active, so 妙控键盘 + 拼音 / Kana / Hangul produces composed CJK output instead of raw Latin.
- Make the IME candidate window and the system IME-switch toast (both globe-key and Caps Lock paths) render correctly for the offscreen `UITextView` IME proxy on iPad.
- Software keyboard CJK composition is **not** addressed in this PR — see "What's still broken" below. Tracking continues on issue #18.

## Why these files are necessary

### Routing (`5022fb3`)

- `VVTerm/GhosttyTerminal/TerminalHardwareTextInputRoutingPolicy.swift` — centralizes when a hardware press should bypass the direct ghostty path and flow through UIKit's IME composition. Without this, CJK IMEs never start composition (the first keystroke goes straight to ghostty as raw Latin).
- `VVTermTests/TerminalHardwareTextInputRoutingPolicyTests.swift` — decision-matrix coverage for the routing policy.

### Visibility (`6027d02`)

`VVTerm/GhosttyTerminal/GhosttyTerminalView+iOS.swift` — four coordinated tweaks to the IME proxy `UITextView` so iPadOS' IME UI subsystem accepts it:

1. **Move the proxy from `(-10000, -10000)` to `(0, 0)`** so UIKit converts our `caretRect(for:)` value (in terminal-view coords from `ghostty_surface_ime_point`) back into the right window position. With an offscreen origin the candidate window anchored ~10000 points outside the screen.
2. **Raise `alpha` from `0.01` to `1.0`**. iPadOS suppresses the Caps Lock "拼音" / "ABC" toast when the focused text input has alpha < 1. The proxy stays visually silent via clear background, clear text/tint, and a no-op `draw(_:)`.
3. **Override `caretRect(for:)` to return a center anchor when there is no active composition.** iOS anchors the Caps Lock toast on this rect, so without an explicit center anchor the toast clipped against the status bar (or followed the terminal cursor when composing and clipped at edges). Composition still anchors at the ghostty cursor for the candidate window.
4. **Return `nil` from `textInputContextIdentifier`.** A non-nil identifier makes iOS persist a per-view IME and treats globe-key switches as "automatic", suppressing the system "拼音" / "English" toast that Notes / Mail show. VVTerm has only one text input, so per-view IME memory has no benefit.

### Hardening from review (`705c6d6`, `3855731`)

- `VVTerm/GhosttyTerminal/GhosttyTerminalView+iOS.swift` — set `accessibilityElementsHidden = true` on the proxy. With the proxy now on-screen at `alpha = 1.0`, an empty 1×1 element should not surface to VoiceOver as a focusable text input.
- `VVTermTests/TerminalHardwareTextInputRoutingPolicyTests.swift` — pin the modifier-priority precedence: even when a CJK input method is active, `Ctrl-`, `Cmd-`, and `Alt-` keystrokes must stay on the direct ghostty path so terminal shortcuts (Ctrl-C, Cmd-V, etc.) are never captured by the system IME.

## Verification

Tested on **iPad Air 5 (M1) + Apple Magic Keyboard, iPadOS 26.4.2, real device**.

| Behavior | Status |
|----------|--------|
| Pinyin `n i` → marked text + candidate window at cursor | ✅ |
| Space commits first candidate to terminal (e.g. `你`) | ✅ |
| Globe-key IME switch shows centered "拼音" / "English" toast | ✅ |
| Caps Lock IME switch (en-US ↔ zh-Hans) shows centered toast | ✅ |
| Cursor near screen edge — toast still centered, not clipped | ✅ |
| English typing, Vim arrow keys, Tab, Esc, Ctrl combos | ✅ no regression |
| \`xcodebuild\` iOS Simulator (iPad Pro 13-inch M5) | ✅ |
| \`xcodebuild\` macOS arm64 | ✅ |
| `TerminalHardwareTextInputRoutingPolicyTests` (suite extended in commit 4) | ✅ |

Local \`xcodebuild test\` against the suite remains blocked by my local provisioning/signing environment, unrelated to these changes.

## What's still broken (continues on #18, no new issue opened)

Software keyboard CJK composition does **not** work after this PR. Logs from on-device debugging show iPadOS Pinyin / Kana refuse to call `setMarkedText` against the offscreen `UITextView` proxy at all — they downgrade to direct `insertText` and iOS auto-switches the input mode back to en-US after each keystroke. This is a separate architectural limitation of the proxy approach, not the same bug as the hardware keyboard path.

The likely fix is structural: have `GhosttyTerminalView` itself implement `UITextInput` directly, mirroring Ghostty's macOS path, instead of routing through an offscreen `UITextView`. That's a larger structural change kept out of this PR to stay focused.

(Earlier I'd reported the soft keyboard symptom as "IME inverted" in the issue thread — that diagnosis was wrong; the actual symptom is that composition never engages.)

Refs #18